### PR TITLE
Update jhbuild remote URL for O2 stack install

### DIFF
--- a/install_lalinference_o2.sh
+++ b/install_lalinference_o2.sh
@@ -15,7 +15,7 @@ git pull
 # Download and install jhbuild
 mkdir -p ~/pe/src
 if [ ! -d ~/pe/src/jhbuild ]; then
-  git clone git://git.gnome.org/jhbuild ~/pe/src/jhbuild
+  git clone https://gitlab.gnome.org/GNOME/jhbuild.git ~/pe/src/jhbuild
   cd ~/pe/src/jhbuild
   ./autogen.sh --prefix=~/pe/.local/
   make


### PR DESCRIPTION
@vivienr As the GNOME Foundation has [moved to GitLab](https://www.gnome.org/news/2018/05/gnome-moves-to-gitlab-2/) I have updated the `jhbuild` to point to the new `https` clone path on their GitLab host.

Cloning from current `jhbuild` `url` seems to fail.

In theory I think `git.gnome.org` should redirect to `gitlab.gnome.org/GNOME`, but I there are some potential issues with GitLab and cloning over the `git` protocol ([1](https://gitlab.com/gitlab-org/gitlab-ce/issues/46555), [2](https://gitlab.com/gitlab-com/support-forum/issues/3225)).